### PR TITLE
Make the Keyboard Backlight work again.

### DIFF
--- a/src/ec/lenovo/h8/acpi/ec.asl
+++ b/src/ec/lenovo/h8/acpi/ec.asl
@@ -20,7 +20,7 @@ Device(EC)
 		Offset (0x0d),
 		                    , 4,
 		                    , 2,
-			        KBLT, 2,        /* Keyboard Light */
+			        KBLS, 2,        /* Keyboard Light */
 		Offset (0x0F),
 				    , 7,
 				TBSW, 1,	/* Tablet mode switch */
@@ -46,7 +46,7 @@ Device(EC)
 				WWEB, 1,
 		Offset (0x3B),
 				    , 1,
-				TPLT, 1,	/* Think Light?? */
+				KBLT, 1,	/* Think Light?? */
 				    , 2,
 				USPW, 1,	/* USB Power enable */
 		Offset (0x48),

--- a/src/ec/lenovo/h8/acpi/ec.asl
+++ b/src/ec/lenovo/h8/acpi/ec.asl
@@ -17,6 +17,10 @@ Device(EC)
 				HSPA, 1,
 		Offset (0x0C),
 				LEDS, 8,	/* LED state */
+		Offset (0x0d),
+		                    , 4,
+		                    , 2,
+			        KBLT, 2,        /* Keyboard Light */
 		Offset (0x0F),
 				    , 7,
 				TBSW, 1,	/* Tablet mode switch */
@@ -42,7 +46,7 @@ Device(EC)
 				WWEB, 1,
 		Offset (0x3B),
 				    , 1,
-				KBLT, 1,	/* Keyboard Light */
+				TPLT, 1,	/* Think Light?? */
 				    , 2,
 				USPW, 1,	/* USB Power enable */
 		Offset (0x48),
@@ -116,9 +120,9 @@ Device(EC)
 		Store(Arg0, USPW)
 	}
 
-	Method (LGHT, 1, NotSerialized)
+	Method (LGHT, 1, NotSerialized) // method for thinklight?
 	{
-		Store(Arg0, KBLT)
+		Store(Arg0, TPLT)
 	}
 
 

--- a/src/ec/lenovo/h8/acpi/thinkpad.asl
+++ b/src/ec/lenovo/h8/acpi/thinkpad.asl
@@ -258,7 +258,7 @@ Device (HKEY)
 	{
 		If (HKBL) {
 			/* FIXME: windows and events */
-			Store ( Xor (Arg0, 0x200), \_SB.PCI0.LPCB.EC.KBLT)
+			Store (Arg0, \_SB.PCI0.LPCB.EC.KBLT)
 		}
 	}
 

--- a/src/ec/lenovo/h8/acpi/thinkpad.asl
+++ b/src/ec/lenovo/h8/acpi/thinkpad.asl
@@ -238,12 +238,12 @@ Device (HKEY)
 	 *  Bit 9: Backlight HW present
 	 *  Bit 0-1: Brightness level
 	 */
-	Method (MLCG, 1)
+	Method (MLCG, 0)
 	{
 		If (HKBL) {
 			Store (0x200, Local0)
 			/* FIXME: Support windows and events */
-			Store ( Or (Local0, \_SB.PCI0.LPCB.EC.KBLT), Local0)
+			Store ( Or (Local0, \_SB.PCI0.LPCB.EC.KBLS), Local0)
 			Return (Local0)
 		} Else {
 			Return (0)
@@ -258,7 +258,7 @@ Device (HKEY)
 	{
 		If (HKBL) {
 			/* FIXME: windows and events */
-			Store (Arg0, \_SB.PCI0.LPCB.EC.KBLT)
+			Store (Arg0, \_SB.PCI0.LPCB.EC.KBLS)
 		}
 	}
 

--- a/src/ec/lenovo/h8/acpi/thinkpad.asl
+++ b/src/ec/lenovo/h8/acpi/thinkpad.asl
@@ -242,8 +242,8 @@ Device (HKEY)
 	{
 		If (HKBL) {
 			Store (0x200, Local0)
-			/* FIXME: Support 2bit brightness control */
-			Or (Local0, \_SB.PCI0.LPCB.EC.KBLT, Local0)
+			/* FIXME: Support windows and events */
+			Store ( Or (Local0, \_SB.PCI0.LPCB.EC.KBLT), Local0)
 			Return (Local0)
 		} Else {
 			Return (0)
@@ -257,8 +257,8 @@ Device (HKEY)
 	Method (MLCS, 1)
 	{
 		If (HKBL) {
-			/* FIXME: Support 2bit brightness control */
-			Store (And(Arg0, 1), \_SB.PCI0.LPCB.EC.WWEB)
+			/* FIXME: windows and events */
+			Store ( Xor (Arg0, 0x200), \_SB.PCI0.LPCB.EC.KBLT)
 		}
 	}
 

--- a/src/ec/lenovo/h8/acpi/thinkpad.asl
+++ b/src/ec/lenovo/h8/acpi/thinkpad.asl
@@ -247,7 +247,7 @@ Device (HKEY)
 			Return (Local0)
 		} Else {
 			Return (0)
-		}
+			}
 	}
 
 	/*
@@ -259,7 +259,10 @@ Device (HKEY)
 		If (HKBL) {
 			/* FIXME: windows and events */
 			Store (Arg0, \_SB.PCI0.LPCB.EC.KBLS)
-		}
+			return (Or (0x200, Arg0) //Return per ACPI.
+		} Else {
+			Return (0)
+			}
 	}
 
 	/*


### PR DESCRIPTION
I think previously this was for the thinklight? 2 bits, shmoo bits, the driver wants 0x200 and the backlight level.  Unfortunately this doesn't want to work on windows and I'm not sure why yet. Maybe something doesn't load or I need to throw the DLL in IDA and find out what is up. I have not worked out events yet.. perhaps windows operates on those more.