### PR TITLE
Add red dot to the T440P led.

### DIFF
--- a/src/ec/lenovo/h8/acpi/systemstatus.asl
+++ b/src/ec/lenovo/h8/acpi/systemstatus.asl
@@ -12,6 +12,8 @@ Scope (\_SI)
 			\_SB.PCI0.LPCB.EC.TLED(0x00)
 			/* suspend TLED off */
 			\_SB.PCI0.LPCB.EC.TLED(0x07)
+			/* Red Dot TLED off */
+			\_SB.PCI0.LPCB.EC.TLED(0x0a)
 		}
 
 		If (LEqual (Arg0, 1)) {
@@ -21,6 +23,8 @@ Scope (\_SI)
 			\_SB.PCI0.LPCB.EC.TLED(0x80)
 			/* suspend TLED off */
 			\_SB.PCI0.LPCB.EC.TLED(0x07)
+			/* Red Dot TLED off */
+			\_SB.PCI0.LPCB.EC.TLED(0x0a)
 		}
 
 		If (LEqual (Arg0, 2)) {
@@ -30,6 +34,8 @@ Scope (\_SI)
 			\_SB.PCI0.LPCB.EC.TLED(0x80)
 			/* suspend LED blinking */
 			\_SB.PCI0.LPCB.EC.TLED(0xc7)
+			/* red dot LED blinking */
+			\_SB.PCI0.LPCB.EC.TLED(0xca)
 		}
 
 		If (LEqual (Arg0, 3)) {
@@ -39,6 +45,8 @@ Scope (\_SI)
 			\_SB.PCI0.LPCB.EC.TLED(0xa0)
 			/* suspend TLED on */
 			\_SB.PCI0.LPCB.EC.TLED(0x87)
+			/* red dot TLED pulsing */
+			\_SB.PCI0.LPCB.EC.TLED(0xaa)
 		}
 	}
 }


### PR DESCRIPTION
It was just on all the time even in suspend. Now it only does the blinkadoodle in suspend and is off otherwise.

Bug (or feature?): it's still on at cold boot, i guess you can tell if your system rebooted....